### PR TITLE
Fix/codec recursion

### DIFF
--- a/lab3/codec.py
+++ b/lab3/codec.py
@@ -91,7 +91,7 @@ class Encoding:
             return
         elif type(obj) is list:
             for o in obj:
-                self.add_obj(obj)
+                self.add_obj(o)
         elif type(obj) is int:
             self.add_int(obj)
         elif type(obj) is dict:


### PR DESCRIPTION
When trying to add a list to an encoding with `add_obj`, the current code causes infinite recursion by trying to repeatedly add the list itself. This fixes this error.